### PR TITLE
Integrate extension options into browser UI

### DIFF
--- a/src/manifest.json
+++ b/src/manifest.json
@@ -17,6 +17,10 @@
   "action": {
     "default_popup": "popup.html"
   },
+  "options_ui": {
+    "page": "popup.html",
+    "open_in_tab": false
+  },
   "icons": {
     "16": "icons/maps4html16.png",
     "32": "icons/maps4html32.png",

--- a/src/popup.html
+++ b/src/popup.html
@@ -6,11 +6,11 @@
   <link href="css/bootstrap.min.css" rel="stylesheet">
   <script src="popup.js"></script>
 </head>
-<body>
+<body style="min-width: 18rem; overflow: hidden;">
 <div class="container pt-3 pb-3">
   <h4>MapML Extension</h4>
 
-  <div class="card mb-2" style="width: 18rem;">
+  <div class="card mb-2">
     <div class="card-body">
       <h6 class="card-title">General Settings</h6>
       <button id="clear" type="button" class="btn btn-light">Clear Storage</button>
@@ -20,7 +20,7 @@
       </div>
     </div>
   </div>
-  <div class="card" style="width: 18rem;">
+  <div class="card">
     <div class="card-body">
       <h6 class="card-title">Accessibility Settings</h6>
       <div class="form-check form-switch">


### PR DESCRIPTION
Integrate extension options into browser UI accessible via browser-provided buttons. Benefits:
 - this makes options a bit easier to discover if user did not pin extension to the browser chrome
 - extension can programmatically direct user to it by calling [`chrome.runtime.openOptionsPage`](https://developer.chrome.com/docs/extensions/reference/runtime/#method-openOptionsPage)

[Documentation](https://developer.chrome.com/docs/extensions/mv3/options/#embedded_options)

![image](https://user-images.githubusercontent.com/45960703/181884649-7adf49a9-ed06-4368-8e51-e36dcdaddf73.png)
