### PR TITLE
Refactor: remove resources/* from web_accessible_resources

### DIFF
--- a/src/manifest.json
+++ b/src/manifest.json
@@ -11,7 +11,7 @@
     "scripting",
     "declarativeNetRequest"
   ],
-  "host_permissions" : [
+  "host_permissions": [
     "<all_urls>"
   ],
   "action": {
@@ -32,8 +32,8 @@
     "service_worker": "background.js"
   },
   "web_accessible_resources": [{
-    "resources": ["dist/*", "resources/*"],
-       "matches": [ "<all_urls>" ]
+    "resources": ["dist/*"],
+    "matches": ["<all_urls>"]
   }],
   "content_scripts": [{
     "run_at": "document_start",


### PR DESCRIPTION
 - Remove `"resources/*"` from `web_accessible_resources`: extension initiates loading of all files within `resources/` folder from `background.js` by calling `chrome.scripting.insertCSS` and `chrome.scripting.executeScript` within extension's origin. This is not considered as "accessing from web", even though they are technically inserted into the web contexts.
 - Format the file for consistency