### PR TITLE
Refactor: avoid waiting in tests

### DIFF
--- a/test/e2e/basics/load.test.js
+++ b/test/e2e/basics/load.test.js
@@ -1,11 +1,11 @@
-const { test, expect, chromium } = require('@playwright/test');
+import { test, expect, chromium } from '@playwright/test';
 
 test.describe("Basic Load", () => {
   let page;
   let context;
   test.beforeAll(async () => {
     context = await chromium.launchPersistentContext('');
-    page = await context.newPage();
+    page = context.pages().find((page) => page.url() === 'about:blank') || await context.newPage();
     await page.goto("test/e2e/basics/locale.html");
   });
 

--- a/test/e2e/basics/locale.test.js
+++ b/test/e2e/basics/locale.test.js
@@ -1,11 +1,12 @@
-const { test, expect, chromium } = require('@playwright/test');
-const path = require("path");
+import { test, expect, chromium } from '@playwright/test';
+import path from 'path';
+
 test.describe("Locale Tests", () => {
   let page;
   let context;
   test.beforeAll(async () => {
     context = await chromium.launchPersistentContext('');
-    page = await context.newPage();
+    page = context.pages().find((page) => page.url() === 'about:blank') || await context.newPage();
     await page.goto("test/e2e/basics/locale.html");
   });
 

--- a/test/e2e/basics/popup.test.js
+++ b/test/e2e/basics/popup.test.js
@@ -1,11 +1,11 @@
-const { test, expect, chromium } = require('@playwright/test');
+import { test, expect, chromium } from '@playwright/test';
 
 test.describe("Popup test", () => {
     let page;
     let context;
     test.beforeAll(async () => {
         context = await chromium.launchPersistentContext('');
-        page = await context.newPage();
+        page = context.pages().find((page) => page.url() === 'about:blank') || await context.newPage();
 
         let [background] = context.serviceWorkers();
         if (!background)
@@ -27,9 +27,7 @@ test.describe("Popup test", () => {
         }
 
         let newPage = await context.newPage();
-        await newPage.waitForTimeout(1000);
-        await newPage.goto("test/e2e/basics/locale.html");
-        await newPage.waitForTimeout(500);
+        await newPage.goto("test/e2e/basics/locale.html", { waitUntil: "domcontentloaded" });
         await newPage.keyboard.press("Tab");
         await newPage.waitForTimeout(500);
         await newPage.keyboard.press("ArrowUp");
@@ -42,15 +40,15 @@ test.describe("Popup test", () => {
 
         const announceMovement = await newPage.$eval(
             "xpath=//html/body/mapml-viewer >> css=div > output",
-            (output) => output.innerHTML
+            (output) => output.textContent
         );
 
         await newPage.close();
-        await expect(featureIndexOverlay === null).toEqual(false);
-        await expect(announceMovement).toEqual("zoom level 2 column 10 row 11");
+        expect(featureIndexOverlay).not.toEqual(null);
+        expect(announceMovement).toEqual("zoom level 2 column 10 row 11");
     });
 
-    test("Turn off options", async ()=>{
+    test("Turn off options", async () => {
         await page.keyboard.press("Space");
         for(let i = 0; i < 2; i++) {
             await page.keyboard.press("Shift+Tab");
@@ -59,9 +57,7 @@ test.describe("Popup test", () => {
 
         await page.waitForTimeout(1000);
         let newPage = await context.newPage();
-        await newPage.waitForTimeout(1000);
-        await newPage.goto("test/e2e/basics/locale.html");
-        await newPage.waitForTimeout(500);
+        await newPage.goto("test/e2e/basics/locale.html", { waitUntil: "domcontentloaded" });
         await newPage.keyboard.press("Tab");
         await newPage.waitForTimeout(500);
         await newPage.keyboard.press("ArrowUp");
@@ -74,15 +70,14 @@ test.describe("Popup test", () => {
 
         const output = await newPage.$eval(
             "xpath=//html/body/mapml-viewer >> css=div > output",
-            (output) => output.innerHTML
+            (output) => output.textContent
         );
 
-        await newPage.goto("https://geogratis.gc.ca/mapml/en/cbmtile/cbmt/?alt=xml");
-        await newPage.waitForTimeout(1000);
+        await newPage.goto("https://geogratis.gc.ca/mapml/en/cbmtile/cbmt/?alt=xml", { waitUntil: "domcontentloaded" });
         const map = await page.$("xpath=//html/body/mapml-viewer");
 
-        await expect(featureIndexOverlay).toEqual(null);
-        await expect(output).toEqual("");
-        await expect(map).toEqual(null);
+        expect(featureIndexOverlay).toEqual(null);
+        expect(output).toEqual("");
+        expect(map).toEqual(null);
     });
 });


### PR DESCRIPTION
Migrate from `waitForTimeout` to `waitForFunction`. This speeds up tests by 25% on my machine, I think greater speedups can be achieved by making `waitForFunction` run more frequently, but I didn't want to tamper with this option just yet.