### PR TITLE
Register content scripts dynamically

### DIFF
--- a/src/manifest.json
+++ b/src/manifest.json
@@ -5,6 +5,7 @@
   "description": "__MSG_extDescription__",
   "manifest_version": 3,
   "permissions": [
+    "scripting",
     "storage",
     "unlimitedStorage",
     "tabs",
@@ -34,19 +35,5 @@
   "web_accessible_resources": [{
     "resources": ["dist/*"],
     "matches": ["<all_urls>"]
-  }],
-  "content_scripts": [{
-    "run_at": "document_start",
-    "matches": [
-      "<all_urls>"
-      ],
-    "js": [
-      "content.js"
-    ]
-  },
-  {
-    "run_at": "document_idle",
-    "matches": ["<all_urls>"],
-    "js": ["sniffForMapML.js"]
   }]
 }

--- a/src/popup.js
+++ b/src/popup.js
@@ -4,6 +4,7 @@ let options = {};
  * Saves the options to storage
  */
 function saveOptions() {
+  chrome.runtime.sendMessage({type: 'options', options});
   chrome.storage.local.set({
     options: options,
   });

--- a/src/sniffForMapML.js
+++ b/src/sniffForMapML.js
@@ -1,13 +1,6 @@
-function sendMessage(message) {
-    chrome.storage.local.get("options", function (items) {
-        const renderMap = items.options ? items.options.renderMap : false;
-        if (renderMap) chrome.runtime.sendMessage(message);
-    });
-}
-
 const mapml = document.querySelector("mapml-");
 if(mapml) {
-    sendMessage(document.contentType === "text/html" ? "html" : "xml");
+    chrome.runtime.sendMessage(document.contentType === "text/html" ? "html" : "xml");
 } else if(document.contentType === "text/mapml"){
-    sendMessage("mapml");
+    chrome.runtime.sendMessage("mapml");
 }


### PR DESCRIPTION
This is a really minor optimization: do not run CS at all if extension is disabled. Considering how tiny CS are, it is a very small efficiency gain.